### PR TITLE
Synchronize search history

### DIFF
--- a/LocationPicker/SearchHistoryManager.swift
+++ b/LocationPicker/SearchHistoryManager.swift
@@ -28,6 +28,7 @@ struct SearchHistoryManager {
 		if !alreadyInHistory {
 			history.insert(dic, at: 0)
 			defaults.set(history, forKey: HistoryKey)
+            defaults.synchronize()
 		}
 	}
 }


### PR DESCRIPTION
UserDefaults should be explicitly synchronized. Apple's documentation is misleading imho, if the LocationPicker gets dismissed too early the history might not get saved.

Could you please provide a new cocoapods release after merging this? I'd like to get rid of my fork 😉 

