### PR TITLE
Drop the available flag on searchTextFieldColor

### DIFF
--- a/LocationPicker/LocationPickerViewController.swift
+++ b/LocationPicker/LocationPickerViewController.swift
@@ -57,7 +57,6 @@ open class LocationPickerViewController: UIViewController {
 	/// default: .default
 	public var statusBarStyle: UIStatusBarStyle = .default
 
-    //@available(iOS 13.0, *)
     public lazy var searchTextFieldColor: UIColor = .clear
 	
 	public var mapType: MKMapType = .hybrid {

--- a/LocationPicker/LocationPickerViewController.swift
+++ b/LocationPicker/LocationPickerViewController.swift
@@ -57,7 +57,7 @@ open class LocationPickerViewController: UIViewController {
 	/// default: .default
 	public var statusBarStyle: UIStatusBarStyle = .default
 
-    @available(iOS 13.0, *)
+    //@available(iOS 13.0, *)
     public lazy var searchTextFieldColor: UIColor = .clear
 	
 	public var mapType: MKMapType = .hybrid {


### PR DESCRIPTION
Xcode does no longer allow to have that variable depending on the OS version, so this has to be removed. As a conclusion you should set the minimum OS version to iOS 13+